### PR TITLE
dmenu cmd fix, remove hard-coded paths

### DIFF
--- a/slip
+++ b/slip
@@ -5,8 +5,9 @@ set -eo pipefail
 # Sane defaults in case of not being set in the config / config not existing.
 DMENU_CMD="dmenu -f -i -dim 0.5 -h 17 -p slip -fn gohup -w 2560 -y 712.5 -nb #c3bea1 -nf #787564 -sb #787564 -sf #c3bea1"
 RECORD_PIDFILE="/tmp/slip_record.pid"
-IMAGES="/home/toqoz/Pictures"
-VIDEOS="/home/toqoz/Videos"
+IMAGES="$HOME/Pictures"
+VIDEOS="$HOME/Videos"
+
 DMENU_PROMPT="slip"
 
 # Load config.

--- a/slip
+++ b/slip
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 # Sane defaults in case of not being set in the config / config not existing.
-DMENU_CMD="dmenu -f -i -dim 0.5 -h 17 -p slip -fn gohup -w 2560 -y 712.5 -nb #c3bea1 -nf #787564 -sb #787564 -sf #c3bea1"
+
 RECORD_PIDFILE="/tmp/slip_record.pid"
 IMAGES="$HOME/Pictures"
 VIDEOS="$HOME/Videos"
@@ -13,6 +13,8 @@ DMENU_PROMPT="slip"
 # Load config.
 CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/slip/config"
 [ -f $CONFIG ] && source $CONFIG
+
+DMENU_CMD="dmenu -f -i -p $DMENU_PROMPT"
 
 # Dmenu prompts.
 DMENU_OPTS="screenshot

--- a/slip
+++ b/slip
@@ -11,7 +11,8 @@ VIDEOS="$HOME/Videos"
 DMENU_PROMPT="slip"
 
 # Load config.
-source "$HOME/.config/slip/config"
+CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/slip/config"
+[ -f $CONFIG ] && source $CONFIG
 
 # Dmenu prompts.
 DMENU_OPTS="screenshot


### PR DESCRIPTION
- The DMENU_CMD used non-existent flags, which I removed. Also removed the color definitions, as those should be set by the user imo(f.e. by making a dmenu wrapper script)
- Added a check for config existence, such that script does not fail, if it does not exist
- Replaced the hard-coded /home/toqoz path by $HOME
- Made the script use $XDG_CONFIG_HOME variable, see [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
